### PR TITLE
Update CircleCI configuration to use workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,6 @@
 version: 2
 jobs:
-  build:
-    branches:
-      ignore:
-        - /.*/
+  build_upload:
     docker:
       - image: docker:stable
     working_directory: /root/working_directory
@@ -29,8 +26,13 @@ jobs:
             docker tag $DOCKERHUB_ORGANIZATION/$CIRCLE_PROJECT_REPONAME:$TAG $DOCKERHUB_ORGANIZATION/$CIRCLE_PROJECT_REPONAME:latest
             docker push $DOCKERHUB_ORGANIZATION/$CIRCLE_PROJECT_REPONAME:latest
           fi
-deployment:
-  fake_deploy_for_cci2:
-    tag: /v.*/
-    commands:
-      - echo "make tags run in 2.0"
+workflows:
+  version: 2
+  release-docker-images:
+    jobs:
+      - build_upload:
+          filters:
+            tags:
+              only: /v.*/
+            branches:
+              ignore: /.*/


### PR DESCRIPTION
This is a proper way to migrate to version 2.0 of Circle CI.