### PR TITLE
Fix unit conversion

### DIFF
--- a/config/templates/template.erb
+++ b/config/templates/template.erb
@@ -6,7 +6,7 @@ DESCRIPTION = "<%= "#{appliance.title} - #{appliance.description}" %>"
 DESCRIPTION = "<%= appliance.title %>"
 <% end %>
 
-MEMORY = "<%= appliance.ram != 0 ? appliance.ram : 1024 %>"
+MEMORY = "<%= appliance.ram != 0 ? (appliance.ram / (1024**2)) : 1024 %>"
 CPU = "<%= appliance.core != 0 ? appliance.core : 0.25 %>"
 VCPU = "<%= appliance.core != 0 ? appliance.core : 1 %>"
 


### PR DESCRIPTION
Appliance memory information from image list is in bytes and OpenNebula
takes values in megabytes. This commit adds the necessary conversion.